### PR TITLE
Example JSON in mustache templates has to be valid.

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Mustache Lint
         if: ${{ always() }}
-        run: moodle-plugin-ci mustache || true
+        run: moodle-plugin-ci mustache
 
       - name: Grunt
         if: ${{ always() }}

--- a/templates/settings_config_color.mustache
+++ b/templates/settings_config_color.mustache
@@ -47,7 +47,7 @@
         "id": "created_id_of_settings_field",
         "name": "created_name_of_settings_field",
         "readonly": false,
-        "size": size of the field (int or percentage string),
+        "size": 15,
         "colors": [
             {
                 "name": {
@@ -63,7 +63,6 @@
                     "value": "hex code of first color"
                 }
             },
-            ...
             {
                 "name": {
                     "id": "created_id_of_settings_field_name_4",


### PR DESCRIPTION
If the example content isn't valid JSON here https://moodle.org/plugins/tiny_fontcolor/versions the precheck doesn't show a green tick.